### PR TITLE
Replace deprecated OutputPage::parse(), which will be removed from MW

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -7,6 +7,9 @@
 	"version": "1.1.0",
 	"descriptionmsg": "incidentreporting-desc",
 	"type": "specialpage",
+	"requires": {
+		"MediaWiki": ">= 1.32.0"
+	},
 	"AvailableRights": [
 		"viewincidents",
 		"editincidents"

--- a/includes/IncidentReportingFormFactory.php
+++ b/includes/IncidentReportingFormFactory.php
@@ -282,7 +282,7 @@ class IncidentReportingFormFactory {
 						'section' => 'logs',
 						'subsection' => (string)$ldata->log_id,
 						'raw' => true,
-						'default' => $context->getOutput()->parse( $ldata->log_action )
+						'default' => $context->getOutput()->parseAsInterface( $ldata->log_action )
 					];
 				}
 			} else {


### PR DESCRIPTION
The OutputPage::parse() method emits untidy output and is often used with the wrong user interface/content language selection. Replace with the new methods added in MW 1.32 which are tidy and consistent.

Bug: T198214