### PR TITLE
Fix fatal in less compiler on MediaWiki 1.37.0+

### DIFF
--- a/modules/ext.incidentreporting.oouiform.ooui.less
+++ b/modules/ext.incidentreporting.oouiform.ooui.less
@@ -1,3 +1,5 @@
+@import 'mediawiki.mixins';
+
 /* Reuses colors from mediawiki.legacy/shared.css */
 .mw-email-not-authenticated .oo-ui-labelWidget,
 .mw-email-none .oo-ui-labelWidget {

--- a/modules/ext.incidentreporting.oouiform.ooui.less
+++ b/modules/ext.incidentreporting.oouiform.ooui.less
@@ -1,5 +1,3 @@
-@import 'mediawiki.mixins';
-
 /* Reuses colors from mediawiki.legacy/shared.css */
 .mw-email-not-authenticated .oo-ui-labelWidget,
 .mw-email-none .oo-ui-labelWidget {
@@ -72,7 +70,7 @@
 	.mw-baseform-faketabs {
 		border-width: 0;
 		border-radius: 0;
-		.box-shadow( none );
+		box-shadow: none;
 
 		> .oo-ui-menuLayout > .oo-ui-menuLayout-content > .oo-ui-stackLayout {
 			margin-bottom: 1em;


### PR DESCRIPTION
The `.box-shadow()` mixin was deprecated in 1.36.0, and removed in 1.37.0.
wikimedia/mediawiki@48cd955